### PR TITLE
Fix to stop monitoring scripts from double-counting products in the g…

### DIFF
--- a/monitoring/opera_daily_products_query.py
+++ b/monitoring/opera_daily_products_query.py
@@ -175,10 +175,12 @@ def get_products(collection, date, north_america_flag=False, central_america_fla
 
     api = GranuleQuery()
     api.short_name(collection)
+    datetime_start = datetime.datetime(date.year, date.month, date.day, 0, 0, 0)
+    datetime_end = datetime.datetime(date.year, date.month, date.day, 23, 59, 59)
     if "DISP" in collection:
-        api.revision_date(date, date + timedelta(days=1))
+        api.revision_date(datetime_start, datetime_end)
     else:
-        api.temporal(date, date + timedelta(days=1))
+        api.temporal(datetime_start, datetime_end)
     if north_america_flag:
         api.polygon(NORTH_AMERICA_POLYGON)
     elif central_america_flag:


### PR DESCRIPTION
A fix to stop the monitoring scripts from overcounting products.  See Issue #122 for more info on the bug report.

## Purpose
- Clear, easy-to-understand sentences outlining the purpose of the PR
## Proposed Changes
- [ADD] ...
- [CHANGE] ...
- [FIX] ...
## Issues
- Links to relevant issues
- Example: issue-XYZ
## Testing
- Provide some proof you've tested your changes 
- Example: test results available at ...
- Example: tested on operating system ...
