### PR TITLE
Fix Innacurate DSWX-HSL Data

### DIFF
--- a/monitoring/latency_graph.py
+++ b/monitoring/latency_graph.py
@@ -38,9 +38,9 @@ COLLECTIONS =  ["OPERA_L3_DSWX-S1_V1", "OPERA_L3_DSWX-HLS_V1", "OPERA_L2_RTC-S1_
 
 OUT_TO_INP_DICT = {
     "DSWx-HLS": ["HLSL30", "HLSS30"],  # DSWx-HLS uses both Landsat and Sentinel-2 inputs
-    "DSWx-S1": "OPERA_L2_RTC-S1_V1",
-    "RTC-S1": "SENTINEL-1A_SLC",
-    "CSLC-S1": "SENTINEL-1A_SLC"
+    "DSWx-S1": ["OPERA_L2_RTC-S1_V1"],
+    "RTC-S1": ["SENTINEL-1A_SLC"],
+    "CSLC-S1": ["SENTINEL-1A_SLC"]
 }
 
 def roundup(x):
@@ -256,15 +256,8 @@ def cmr_input_search(cmr_input_begin_time, cmr_input_end_time, output_prod_type)
     search the input granules and from that parse and match the inputs.
     Supports querying multiple input collections (e.g., HLSL30 and HLSS30 for DSWx-HLS).
     '''
-    # Get collection(s) from the mapping, can be a string or list
-    inp_collections = OUT_TO_INP_DICT[output_prod_type]
-    
-    # Convert to list if it's a single string
-    if isinstance(inp_collections, str):
-        collections_to_query = [inp_collections]
-    else:
-        collections_to_query = inp_collections
-    
+    collections_to_query = OUT_TO_INP_DICT[output_prod_type]
+
     print("input_search begin time: ", cmr_input_begin_time)
     print("input_search end time: ", cmr_input_end_time)
     cmr_input_begin_time = string_to_datetime(cmr_input_begin_time, gran_input=output_prod_type)


### PR DESCRIPTION
## Purpose
Fixes #121 
[https://github.com/nasa/opera-sds/issues/121](url)

DSWX-HLS products can use EITHER HLSL30 (Landsat) OR HLSS30 (Sentinel-2) as inputs, but the code only maps to HLSL30. This causes the latency calculation to:
1: Successfully extract input granule names from DSWX-HLS products (both HLSL30 and HLSS30)
2: Only search CMR for HLSL30 inputs when trying to get metadata (line 259: short_name = OUT_TO_INP_DICT[output_prod_type])
3: Miss all HLSS30 inputs, leading to incomplete/inaccurate latency data
The DSWX-HLS latency chart is showing inaccurate data likely because it's only calculating latency for products that used HLSL30 inputs, missing approximately half of the DSWX-HLS products that used HLSS30 inputs.





